### PR TITLE
Declare AHFloat using type alias rather than macro.

### DIFF
--- a/AHEasing/easing.h
+++ b/AHEasing/easing.h
@@ -18,10 +18,11 @@
 #endif
 
 #ifdef AH_EASING_USE_DBL_PRECIS
-#define AHFloat double
+#define AH_FLOAT_TYPE double
 #else
-#define AHFloat float
+#define AH_FLOAT_TYPE float
 #endif
+typedef AH_FLOAT_TYPE AHFloat;
 
 #if defined __cplusplus
 extern "C" {


### PR DESCRIPTION
This changes the way that AHFloat can be used.  One notable
improvement is better compatibility with C files bridged to Swift,
where the use of the macro is limited (current Swift 3.0.1).  In
particular, the macro `AHFloat` cannot be used to convert numeric
types in Swift, but the typedef (apparently) can.

See the declaration of the CoreGraphics similar type `CGFloat` in `CGBase.h`:
```
/* Definition of `CGFLOAT_TYPE', `CGFLOAT_IS_DOUBLE', `CGFLOAT_MIN', and
   `CGFLOAT_MAX'. */

#if defined(__LP64__) && __LP64__
# define CGFLOAT_TYPE double
# define CGFLOAT_IS_DOUBLE 1
# define CGFLOAT_MIN DBL_MIN
# define CGFLOAT_MAX DBL_MAX
#else
# define CGFLOAT_TYPE float
# define CGFLOAT_IS_DOUBLE 0
# define CGFLOAT_MIN FLT_MIN
# define CGFLOAT_MAX FLT_MAX
#endif

/* Definition of the `CGFloat' type and `CGFLOAT_DEFINED'. */

typedef CGFLOAT_TYPE CGFloat;
#define CGFLOAT_DEFINED 1
```

Perhaps this change could also include checking the defined value of `__LP64__`.

For more information on restrictions imposed by Swift bridging, see [Apple documentation](https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html):

> Simple Macros
> 
> Where you typically used the #define directive to define a primitive constant in C and Objective-C, in Swift you use a global constant instead. For example, the constant definition #define FADE_ANIMATION_DURATION 0.35 can be better expressed in Swift with let FADE_ANIMATION_DURATION = 0.35. Because simple constant-like macros map directly to Swift global variables, **the compiler automatically imports simple macros defined in C and Objective-C source files**.
> 
> Complex Macros
> 
> Complex macros are used in C and Objective-C but have no counterpart in Swift. Complex macros are macros that do not define constants, including parenthesized, function-like macros. You use complex macros in C and Objective-C to avoid type-checking constraints or to avoid retyping large amounts of boilerplate code. However, macros can make debugging and refactoring difficult. In Swift, you can use functions and generics to achieve the same results without any compromises. **Therefore, the complex macros that are in C and Objective-C source files are not made available to your Swift code.**

